### PR TITLE
Remove droplevels

### DIFF
--- a/R/longCombat.R
+++ b/R/longCombat.R
@@ -32,7 +32,7 @@ longCombat <- function(idvar, timevar, batchvar, features,
     stop(message)
   }
   # make batch a factor if not already
-  batch <- droplevels(as.factor(data[,batchvar]))
+  # batch <- droplevels(as.factor(data[,batchvar]))
   # check for batches with only one observation
   if (min(table(batch)) <= 1) {
     batch_single <- paste(names(table(batch))[table(batch) <= 1], collapse=', ')


### PR DESCRIPTION
The following line throws an error in newer versions of R and stops the rest of the code from running
batch <- droplevels(as.factor(data[,batchvar]))
As the description already specifies that batchvar needs to be a factor, this can be omitted.