### PR TITLE
Fix the error around the batch variable

### DIFF
--- a/R/longCombat.R
+++ b/R/longCombat.R
@@ -32,7 +32,7 @@ longCombat <- function(idvar, timevar, batchvar, features,
     stop(message)
   }
   # make batch a factor if not already
-  batch <- droplevels(as.factor(data[,batchvar]))
+  batch <- droplevels(as.factor(data[[batchvar]]))
   # check for batches with only one observation
   if (min(table(batch)) <= 1) {
     batch_single <- paste(names(table(batch))[table(batch) <= 1], collapse=', ')


### PR DESCRIPTION
Using [[]] allows pulling the column by name while not returning a list with columns